### PR TITLE
security: supply chain hardening — pin actions, remove curl|sh, pin build backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,12 +12,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
 
       - name: Build package
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Repository = "https://github.com/IceRhymers/uc-mcp-proxy"
 Issues = "https://github.com/IceRhymers/uc-mcp-proxy/issues"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.29.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]

--- a/skills/uc-mcp-proxy/SKILL.md
+++ b/skills/uc-mcp-proxy/SKILL.md
@@ -137,4 +137,4 @@ Restart Claude Code/Desktop after editing `.mcp.json`. The proxy must be running
 - Check your workspace firewall/network policies
 
 *`uvx: command not found`*
-Install `uv`: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+Install `uv` via `pip install uv` or `brew install uv`. Alternatively, install `uc-mcp-proxy` directly: `pip install uc-mcp-proxy` (always verify the package source is pypi.org/project/uc-mcp-proxy).


### PR DESCRIPTION
## Summary

- *Pin GitHub Actions to commit SHAs* in `ci.yml` and `publish.yml` — prevents tag-hijack attacks, especially critical for the publish workflow which has `id-token: write` permission (fixes #3)
- *Replace `curl | sh` install pattern* in `skills/uc-mcp-proxy/SKILL.md` with `pip install uv` / `brew install uv` alternatives (fixes #4)
- *Pin hatchling build backend* to `1.29.0` in `pyproject.toml` to prevent build-system drift (fixes #5)

## Test plan

- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm `uv build` still produces a valid package with pinned hatchling
- [ ] Review SHA pins match expected action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)