### PR TITLE
feat: inject MCP _meta params into tools/call requests via --meta flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,37 @@ uc-mcp-proxy --url <MCP_SERVER_URL> [--profile <DATABRICKS_PROFILE>] [--auth-typ
 | `--url` | **(required)** Remote MCP server URL |
 | `--profile` | Databricks CLI profile name (uses default if omitted) |
 | `--auth-type` | Databricks auth type, e.g. `databricks-cli` |
+| `--header KEY=VALUE` | Extra HTTP header forwarded to upstream (repeatable) |
+
+## Meta Parameters (Managed MCP)
+
+Databricks Managed MCP servers accept transport-level HTTP headers for configuration — for example, selecting a SQL warehouse or scoping to a catalog/schema. Use `--header` to forward these:
+
+```bash
+uvx uc-mcp-proxy \
+  --url https://workspace.databricks.com/api/2.0/mcp/functions/main/default \
+  --header x-databricks-warehouse-id=abc123 \
+  --header x-databricks-catalog=main \
+  --header x-databricks-schema=default
+```
+
+Or in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "sql-mcp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "uc-mcp-proxy",
+        "--url", "https://workspace.databricks.com/api/2.0/mcp/functions/main/default",
+        "--header", "x-databricks-warehouse-id=abc123"
+      ]
+    }
+  }
+}
+```
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ uc-mcp-proxy --url <MCP_SERVER_URL> [--profile <DATABRICKS_PROFILE>] [--auth-typ
 | `--url` | **(required)** Remote MCP server URL |
 | `--profile` | Databricks CLI profile name (uses default if omitted) |
 | `--auth-type` | Databricks auth type, e.g. `databricks-cli` |
-| `--header KEY=VALUE` | Extra HTTP header forwarded to upstream (repeatable) |
+| `--meta KEY=VALUE` | Meta parameter injected into `tools/call` `_meta` (repeatable) |
 
 ## Meta Parameters (Managed MCP)
 
-Databricks Managed MCP servers accept transport-level HTTP headers for configuration — for example, selecting a SQL warehouse or scoping to a catalog/schema. Use `--header` to forward these:
+Databricks Managed MCP servers accept configuration — for example, selecting a SQL warehouse — via the MCP [`_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic#_meta) field in the JSON-RPC request body, **not** as HTTP headers. See the Databricks [meta-param docs](https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp-meta-param) for the supported keys per server type.
+
+Use `--meta KEY=VALUE` (repeatable) — the proxy merges these into `params._meta` on every outgoing `tools/call` request:
 
 ```bash
 uvx uc-mcp-proxy \
-  --url https://workspace.databricks.com/api/2.0/mcp/functions/main/default \
-  --header x-databricks-warehouse-id=abc123 \
-  --header x-databricks-catalog=main \
-  --header x-databricks-schema=default
+  --url https://workspace.databricks.com/api/2.0/mcp/sql \
+  --meta warehouse_id=abc123
 ```
 
 Or in `.mcp.json`:
@@ -82,13 +82,15 @@ Or in `.mcp.json`:
       "command": "uvx",
       "args": [
         "uc-mcp-proxy",
-        "--url", "https://workspace.databricks.com/api/2.0/mcp/functions/main/default",
-        "--header", "x-databricks-warehouse-id=abc123"
+        "--url", "https://workspace.databricks.com/api/2.0/mcp/sql",
+        "--meta", "warehouse_id=abc123"
       ]
     }
   }
 }
 ```
+
+If the MCP client already sets a `_meta` key that the proxy is also configured to inject, the proxy value wins and a warning is written to stderr.
 
 ## How It Works
 

--- a/src/uc_mcp_proxy/__main__.py
+++ b/src/uc_mcp_proxy/__main__.py
@@ -13,6 +13,8 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from databricks.sdk import WorkspaceClient
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.server.stdio import stdio_server
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCRequest
 
 
 class DatabricksAuth(httpx.Auth):
@@ -51,15 +53,69 @@ async def copy_stream(source: MemoryObjectReceiveStream, dest: MemoryObjectSendS
         await dest.aclose()
 
 
+def inject_meta(
+    message: SessionMessage | Exception,
+    meta: dict[str, str],
+) -> SessionMessage | Exception:
+    """Merge ``meta`` into ``params._meta`` on ``tools/call`` requests.
+
+    Exceptions, notifications, responses, and non-``tools/call`` requests pass
+    through unchanged. Mutates the incoming ``SessionMessage`` in place — this
+    matches how the MCP SDK streams deliver per-message objects (not shared).
+    On key collision the proxy value wins and a warning is printed to stderr.
+    """
+    # Scoped to tools/call because that is the only method Databricks documents
+    # for meta params today; _meta is valid on any request per MCP spec.
+    if isinstance(message, Exception):
+        return message
+    root = message.message.root
+    if not isinstance(root, JSONRPCRequest) or root.method != "tools/call":
+        return message
+    if root.params is None:
+        root.params = {}
+    existing = root.params.get("_meta") or {}
+    for key, value in meta.items():
+        if key in existing:
+            print(
+                f"warning: --meta {key!r} overrides client _meta.{key}",
+                file=sys.stderr,
+            )
+        existing[key] = value
+    root.params["_meta"] = existing
+    return message
+
+
+async def inject_meta_stream(
+    source: MemoryObjectReceiveStream,
+    dest: MemoryObjectSendStream,
+    meta: dict[str, str],
+) -> None:
+    """Like copy_stream, but applies inject_meta to each forwarded message."""
+    try:
+        async for message in source:
+            await dest.send(inject_meta(message, meta))
+    finally:
+        await dest.aclose()
+
+
 async def bridge(
     stdio_read: MemoryObjectReceiveStream,
     stdio_write: MemoryObjectSendStream,
     http_read: MemoryObjectReceiveStream,
     http_write: MemoryObjectSendStream,
+    meta: dict[str, str] | None = None,
 ) -> None:
-    """Bidirectional bridge between stdio and HTTP stream pairs."""
+    """Bidirectional bridge between stdio and HTTP stream pairs.
+
+    When ``meta`` is set, client→server messages are rewritten to carry
+    proxy-configured ``_meta`` on ``tools/call`` requests. The server→client
+    direction is always a transparent copy.
+    """
     async with anyio.create_task_group() as tg:
-        tg.start_soon(copy_stream, stdio_read, http_write)
+        if meta:
+            tg.start_soon(inject_meta_stream, stdio_read, http_write, meta)
+        else:
+            tg.start_soon(copy_stream, stdio_read, http_write)
         tg.start_soon(copy_stream, http_read, stdio_write)
 
 
@@ -67,7 +123,7 @@ async def run(
     url: str,
     profile: str | None = None,
     auth_type: str | None = None,
-    headers: dict[str, str] | None = None,
+    meta: dict[str, str] | None = None,
 ) -> None:
     """Run the proxy: bridge stdio transport to Streamable HTTP with Databricks OAuth."""
     kwargs: dict = {}
@@ -79,12 +135,12 @@ async def run(
     auth = DatabricksAuth(client)
 
     async with stdio_server() as (stdio_read, stdio_write):
-        async with streamablehttp_client(url, headers=headers, auth=auth) as (
+        async with streamablehttp_client(url, auth=auth) as (
             http_read,
             http_write,
             _get_session_id,
         ):
-            await bridge(stdio_read, stdio_write, http_read, http_write)
+            await bridge(stdio_read, stdio_write, http_read, http_write, meta)
 
 
 def main() -> None:
@@ -96,25 +152,29 @@ def main() -> None:
     parser.add_argument("--profile", default=None, help="Databricks CLI profile")
     parser.add_argument("--auth-type", default=None, help="Databricks auth type (e.g. databricks-cli)")
     parser.add_argument(
-        "--header",
+        "--meta",
         action="append",
         default=[],
         metavar="KEY=VALUE",
-        help="Extra HTTP header forwarded to upstream (e.g. --header x-databricks-warehouse-id=abc123). Repeatable.",
+        help=(
+            "Meta parameter injected into the JSON-RPC tools/call _meta object "
+            "(e.g. --meta warehouse_id=abc123). Repeatable. Proxy values win "
+            "on key collision with client-provided _meta."
+        ),
     )
     args = parser.parse_args()
 
-    headers: dict[str, str] | None = None
-    if args.header:
-        headers = {}
-        for h in args.header:
-            key, _, value = h.partition("=")
+    meta: dict[str, str] | None = None
+    if args.meta:
+        meta = {}
+        for m in args.meta:
+            key, _, value = m.partition("=")
             if not value:
-                print(f"Error: --header must be KEY=VALUE, got: {h!r}", file=sys.stderr)
+                print(f"Error: --meta must be KEY=VALUE, got: {m!r}", file=sys.stderr)
                 sys.exit(1)
-            headers[key] = value
+            meta[key] = value
 
-    asyncio.run(run(args.url, args.profile, args.auth_type, headers))
+    asyncio.run(run(args.url, args.profile, args.auth_type, meta))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/uc_mcp_proxy/__main__.py
+++ b/src/uc_mcp_proxy/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import sys
 from typing import Generator, AsyncGenerator
 
 import anyio
@@ -62,7 +63,12 @@ async def bridge(
         tg.start_soon(copy_stream, http_read, stdio_write)
 
 
-async def run(url: str, profile: str | None = None, auth_type: str | None = None) -> None:
+async def run(
+    url: str,
+    profile: str | None = None,
+    auth_type: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> None:
     """Run the proxy: bridge stdio transport to Streamable HTTP with Databricks OAuth."""
     kwargs: dict = {}
     if profile:
@@ -73,7 +79,7 @@ async def run(url: str, profile: str | None = None, auth_type: str | None = None
     auth = DatabricksAuth(client)
 
     async with stdio_server() as (stdio_read, stdio_write):
-        async with streamablehttp_client(url, auth=auth) as (
+        async with streamablehttp_client(url, headers=headers, auth=auth) as (
             http_read,
             http_write,
             _get_session_id,
@@ -89,8 +95,26 @@ def main() -> None:
     parser.add_argument("--url", required=True, help="Remote MCP server URL")
     parser.add_argument("--profile", default=None, help="Databricks CLI profile")
     parser.add_argument("--auth-type", default=None, help="Databricks auth type (e.g. databricks-cli)")
+    parser.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Extra HTTP header forwarded to upstream (e.g. --header x-databricks-warehouse-id=abc123). Repeatable.",
+    )
     args = parser.parse_args()
-    asyncio.run(run(args.url, args.profile, args.auth_type))
+
+    headers: dict[str, str] | None = None
+    if args.header:
+        headers = {}
+        for h in args.header:
+            key, _, value = h.partition("=")
+            if not value:
+                print(f"Error: --header must be KEY=VALUE, got: {h!r}", file=sys.stderr)
+                sys.exit(1)
+            headers[key] = value
+
+    asyncio.run(run(args.url, args.profile, args.auth_type, headers))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,8 +104,9 @@ def mock_http_client(http_streams):
     captured = {}
 
     @asynccontextmanager
-    async def _mock(url, *, auth=None, terminate_on_close=True, **kwargs):
+    async def _mock(url, *, headers=None, auth=None, terminate_on_close=True, **kwargs):
         captured["url"] = url
+        captured["headers"] = headers
         captured["auth"] = auth
         captured["terminate_on_close"] = terminate_on_close
         yield (proxy_read, proxy_write, lambda: "mock-session-id")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -67,11 +67,11 @@ def test_creates_workspace_client_with_auth_type():
                 mock_run.assert_called_once_with("https://example.com/mcp", None, "databricks-cli", None)
 
 
-def test_single_header_parsed_correctly():
-    """--header KEY=VALUE is parsed into a dict and passed to run()."""
+def test_single_meta_parsed_correctly():
+    """--meta KEY=VALUE is parsed into a dict and passed to run()."""
     with patch.object(sys, "argv", [
         "uc-mcp-proxy", "--url", "https://example.com/mcp",
-        "--header", "x-databricks-warehouse-id=abc123",
+        "--meta", "warehouse_id=abc123",
     ]):
         with patch("uc_mcp_proxy.__main__.run") as mock_run:
             mock_run.return_value = MagicMock()
@@ -80,16 +80,16 @@ def test_single_header_parsed_correctly():
                 main()
                 mock_run.assert_called_once_with(
                     "https://example.com/mcp", None, None,
-                    {"x-databricks-warehouse-id": "abc123"},
+                    {"warehouse_id": "abc123"},
                 )
 
 
-def test_multiple_headers_parsed_correctly():
-    """Multiple --header flags produce a dict with all entries."""
+def test_multiple_meta_parsed_correctly():
+    """Multiple --meta flags produce a dict with all entries."""
     with patch.object(sys, "argv", [
         "uc-mcp-proxy", "--url", "https://example.com/mcp",
-        "--header", "x-databricks-warehouse-id=abc123",
-        "--header", "x-databricks-catalog=main",
+        "--meta", "warehouse_id=abc123",
+        "--meta", "catalog=main",
     ]):
         with patch("uc_mcp_proxy.__main__.run") as mock_run:
             mock_run.return_value = MagicMock()
@@ -98,18 +98,15 @@ def test_multiple_headers_parsed_correctly():
                 main()
                 mock_run.assert_called_once_with(
                     "https://example.com/mcp", None, None,
-                    {
-                        "x-databricks-warehouse-id": "abc123",
-                        "x-databricks-catalog": "main",
-                    },
+                    {"warehouse_id": "abc123", "catalog": "main"},
                 )
 
 
-def test_header_without_value_exits_with_error():
-    """--header bad (no =) produces a non-zero exit."""
+def test_meta_without_value_exits_with_error():
+    """--meta bad (no =) produces a non-zero exit."""
     with patch.object(sys, "argv", [
         "uc-mcp-proxy", "--url", "https://example.com/mcp",
-        "--header", "bad",
+        "--meta", "bad",
     ]):
         with pytest.raises(SystemExit) as exc_info:
             from uc_mcp_proxy.__main__ import main
@@ -117,8 +114,8 @@ def test_header_without_value_exits_with_error():
         assert exc_info.value.code == 1
 
 
-def test_no_headers_passes_none():
-    """No --header flags → headers=None (backward-compatible)."""
+def test_no_meta_passes_none():
+    """No --meta flags → meta=None."""
     with patch.object(sys, "argv", ["uc-mcp-proxy", "--url", "https://example.com/mcp"]):
         with patch("uc_mcp_proxy.__main__.run") as mock_run:
             mock_run.return_value = MagicMock()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -38,7 +38,7 @@ def test_default_profile_is_none():
             with patch("uc_mcp_proxy.__main__.asyncio.run"):
                 from uc_mcp_proxy.__main__ import main
                 main()
-                mock_run.assert_called_once_with("https://example.com/mcp", None, None)
+                mock_run.assert_called_once_with("https://example.com/mcp", None, None, None)
 
 
 def test_creates_workspace_client_with_profile():
@@ -51,7 +51,7 @@ def test_creates_workspace_client_with_profile():
             with patch("uc_mcp_proxy.__main__.asyncio.run"):
                 from uc_mcp_proxy.__main__ import main
                 main()
-                mock_run.assert_called_once_with("https://example.com/mcp", "MY_PROFILE", None)
+                mock_run.assert_called_once_with("https://example.com/mcp", "MY_PROFILE", None, None)
 
 
 def test_creates_workspace_client_with_auth_type():
@@ -64,4 +64,65 @@ def test_creates_workspace_client_with_auth_type():
             with patch("uc_mcp_proxy.__main__.asyncio.run"):
                 from uc_mcp_proxy.__main__ import main
                 main()
-                mock_run.assert_called_once_with("https://example.com/mcp", None, "databricks-cli")
+                mock_run.assert_called_once_with("https://example.com/mcp", None, "databricks-cli", None)
+
+
+def test_single_header_parsed_correctly():
+    """--header KEY=VALUE is parsed into a dict and passed to run()."""
+    with patch.object(sys, "argv", [
+        "uc-mcp-proxy", "--url", "https://example.com/mcp",
+        "--header", "x-databricks-warehouse-id=abc123",
+    ]):
+        with patch("uc_mcp_proxy.__main__.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            with patch("uc_mcp_proxy.__main__.asyncio.run"):
+                from uc_mcp_proxy.__main__ import main
+                main()
+                mock_run.assert_called_once_with(
+                    "https://example.com/mcp", None, None,
+                    {"x-databricks-warehouse-id": "abc123"},
+                )
+
+
+def test_multiple_headers_parsed_correctly():
+    """Multiple --header flags produce a dict with all entries."""
+    with patch.object(sys, "argv", [
+        "uc-mcp-proxy", "--url", "https://example.com/mcp",
+        "--header", "x-databricks-warehouse-id=abc123",
+        "--header", "x-databricks-catalog=main",
+    ]):
+        with patch("uc_mcp_proxy.__main__.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            with patch("uc_mcp_proxy.__main__.asyncio.run"):
+                from uc_mcp_proxy.__main__ import main
+                main()
+                mock_run.assert_called_once_with(
+                    "https://example.com/mcp", None, None,
+                    {
+                        "x-databricks-warehouse-id": "abc123",
+                        "x-databricks-catalog": "main",
+                    },
+                )
+
+
+def test_header_without_value_exits_with_error():
+    """--header bad (no =) produces a non-zero exit."""
+    with patch.object(sys, "argv", [
+        "uc-mcp-proxy", "--url", "https://example.com/mcp",
+        "--header", "bad",
+    ]):
+        with pytest.raises(SystemExit) as exc_info:
+            from uc_mcp_proxy.__main__ import main
+            main()
+        assert exc_info.value.code == 1
+
+
+def test_no_headers_passes_none():
+    """No --header flags → headers=None (backward-compatible)."""
+    with patch.object(sys, "argv", ["uc-mcp-proxy", "--url", "https://example.com/mcp"]):
+        with patch("uc_mcp_proxy.__main__.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            with patch("uc_mcp_proxy.__main__.asyncio.run"):
+                from uc_mcp_proxy.__main__ import main
+                main()
+                mock_run.assert_called_once_with("https://example.com/mcp", None, None, None)

--- a/tests/unit/test_meta_injection.py
+++ b/tests/unit/test_meta_injection.py
@@ -1,0 +1,169 @@
+"""Tests for JSON-RPC _meta injection on tools/call messages."""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCMessage, JSONRPCRequest
+
+pytestmark = pytest.mark.unit
+
+
+def _tools_call(params=None) -> SessionMessage:
+    if params is None:
+        params = {"name": "q", "arguments": {}}
+    return SessionMessage(
+        message=JSONRPCMessage(
+            root=JSONRPCRequest(
+                jsonrpc="2.0", id=1, method="tools/call", params=params,
+            )
+        )
+    )
+
+
+def _tools_list() -> SessionMessage:
+    return SessionMessage(
+        message=JSONRPCMessage(
+            root=JSONRPCRequest(
+                jsonrpc="2.0", id=2, method="tools/list", params={},
+            )
+        )
+    )
+
+
+def _tools_call_no_params() -> SessionMessage:
+    return SessionMessage(
+        message=JSONRPCMessage(
+            root=JSONRPCRequest(
+                jsonrpc="2.0", id=3, method="tools/call",
+            )
+        )
+    )
+
+
+def test_inject_meta_adds_meta_to_tools_call():
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    out = inject_meta(_tools_call(), {"warehouse_id": "abc123"})
+
+    assert out.message.root.params["_meta"] == {"warehouse_id": "abc123"}
+
+
+def test_inject_meta_ignores_tools_list():
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    out = inject_meta(_tools_list(), {"warehouse_id": "abc"})
+
+    assert "_meta" not in (out.message.root.params or {})
+
+
+def test_inject_meta_merges_with_existing_meta():
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    msg = _tools_call(
+        params={"name": "q", "arguments": {}, "_meta": {"progressToken": "tok-42"}},
+    )
+    out = inject_meta(msg, {"warehouse_id": "abc"})
+
+    assert out.message.root.params["_meta"] == {
+        "progressToken": "tok-42",
+        "warehouse_id": "abc",
+    }
+
+
+def test_inject_meta_proxy_wins_on_collision(capsys):
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    msg = _tools_call(
+        params={"name": "q", "arguments": {}, "_meta": {"warehouse_id": "client-val"}},
+    )
+    out = inject_meta(msg, {"warehouse_id": "proxy-val"})
+
+    assert out.message.root.params["_meta"]["warehouse_id"] == "proxy-val"
+    err = capsys.readouterr().err
+    assert "warehouse_id" in err
+    assert "override" in err.lower()
+
+
+def test_inject_meta_handles_exception_passthrough():
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    err = RuntimeError("stream fault")
+    assert inject_meta(err, {"warehouse_id": "abc"}) is err
+
+
+def test_inject_meta_handles_missing_params():
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    out = inject_meta(_tools_call_no_params(), {"warehouse_id": "abc"})
+
+    assert out.message.root.params == {"_meta": {"warehouse_id": "abc"}}
+
+
+def test_inject_meta_multiple_keys():
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    out = inject_meta(_tools_call(), {"warehouse_id": "abc", "catalog": "main"})
+
+    assert out.message.root.params["_meta"] == {
+        "warehouse_id": "abc",
+        "catalog": "main",
+    }
+
+
+def test_inject_meta_serializes_correctly():
+    """Round-trip: injected _meta appears in JSON serialization via by_alias."""
+    from uc_mcp_proxy.__main__ import inject_meta
+
+    out = inject_meta(_tools_call(), {"warehouse_id": "abc"})
+    payload = out.message.model_dump_json(by_alias=True, exclude_none=True)
+
+    assert '"_meta":{"warehouse_id":"abc"}' in payload
+
+
+@pytest.mark.anyio
+async def test_inject_meta_stream_rewrites_only_tools_call(memory_stream_pair):
+    from uc_mcp_proxy.__main__ import inject_meta_stream
+
+    source_send, source_recv = memory_stream_pair(16)
+    dest_send, dest_recv = memory_stream_pair(16)
+
+    call = _tools_call()
+    listing = _tools_list()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(inject_meta_stream, source_recv, dest_send, {"warehouse_id": "abc"})
+        await source_send.send(call)
+        await source_send.send(listing)
+        await source_send.aclose()
+
+    results = []
+    async with dest_recv:
+        async for m in dest_recv:
+            results.append(m)
+
+    assert results[0].message.root.params["_meta"] == {"warehouse_id": "abc"}
+    assert "_meta" not in (results[1].message.root.params or {})
+
+
+@pytest.mark.anyio
+async def test_inject_meta_stream_passes_exception_through(memory_stream_pair):
+    from uc_mcp_proxy.__main__ import inject_meta_stream
+
+    source_send, source_recv = memory_stream_pair(4)
+    dest_send, dest_recv = memory_stream_pair(4)
+
+    err = RuntimeError("parse error")
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(inject_meta_stream, source_recv, dest_send, {"warehouse_id": "abc"})
+        await source_send.send(err)
+        await source_send.aclose()
+
+    results = []
+    async with dest_recv:
+        async for m in dest_recv:
+            results.append(m)
+
+    assert results == [err]


### PR DESCRIPTION
## Summary

Adds a repeatable `--meta KEY=VALUE` CLI flag that intercepts `tools/call` JSON-RPC
requests in the client→server direction and merges the specified values into
`params._meta` before forwarding to the upstream Managed MCP server.

Closes #10

## Why not HTTP headers?

The proxy bridges stdio (client) → Streamable HTTP (upstream). The stdio transport
has no header concept, so there is nothing to forward from the client side as HTTP
headers. Injecting into the MCP `_meta` field is the correct in-band mechanism per
the MCP spec.

## Changes

- `src/uc_mcp_proxy/__main__.py`:
  - `inject_meta()` — merges proxy `_meta` into `tools/call` params; warns on collision
  - `inject_meta_stream()` — like `copy_stream`, but applies `inject_meta` per message
  - `bridge()` — uses `inject_meta_stream` on the client→server leg when `--meta` is set
  - `run()` — accepts and forwards `meta` dict
  - `main()` — `--meta KEY=VALUE` argparse flag with validation
- `README.md`: `--meta` flag docs + SQL MCP usage example
- `tests/`: unit tests for injection, collision warning, pass-through, and parsing

## Usage

```sh
uvx uc-mcp-proxy \
  --url https://workspace.databricks.com/api/2.0/mcp/... \
  --meta warehouse_id=abc123 \
  --meta catalog=main
```

Or in `.mcp.json`:

```json
{
  "mcpServers": {
    "sql-mcp": {
      "type": "stdio",
      "command": "uvx",
      "args": [
        "uc-mcp-proxy",
        "--url", "https://workspace.databricks.com/api/2.0/mcp/...",
        "--meta", "warehouse_id=abc123"
      ]
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)