### PR TITLE
feat: add --no-verify-ssl flag for self-signed certificate environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 
 # uv
 .python-version
+
+#omc
+.omc/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ uc-mcp-proxy --url <MCP_SERVER_URL> [--profile <DATABRICKS_PROFILE>] [--auth-typ
 | `--profile` | Databricks CLI profile name (uses default if omitted) |
 | `--auth-type` | Databricks auth type, e.g. `databricks-cli` |
 | `--meta KEY=VALUE` | Meta parameter injected into `tools/call` `_meta` (repeatable) |
+| `--no-verify-ssl` | Disable SSL certificate verification (use with caution — see below) |
 
 ## Meta Parameters (Managed MCP)
 
@@ -91,6 +92,42 @@ Or in `.mcp.json`:
 ```
 
 If the MCP client already sets a `_meta` key that the proxy is also configured to inject, the proxy value wins and a warning is written to stderr.
+
+## SSL Certificate Verification
+
+Some Azure Databricks instances use self-signed or internally-signed certificates that are not trusted by the system's default CA bundle. This causes errors like:
+
+```
+SSL_CERTIFICATE_VERIFY_FAILED: certificate verify failed: unable to get local issuer certificate
+```
+
+Use `--no-verify-ssl` to disable certificate verification:
+
+```bash
+uvx uc-mcp-proxy \
+  --url https://workspace.azuredatabricks.net/api/2.0/mcp/functions/main/default \
+  --no-verify-ssl
+```
+
+Or in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "unity-catalog": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "uc-mcp-proxy",
+        "--url", "https://workspace.azuredatabricks.net/api/2.0/mcp/functions/main/default",
+        "--no-verify-ssl"
+      ]
+    }
+  }
+}
+```
+
+> **Security warning:** `--no-verify-ssl` disables all certificate validation, which exposes connections to man-in-the-middle (MITM) attacks. Only use this flag in trusted network environments (e.g. a private corporate VPN) where you control the network path to the Databricks workspace.
 
 ## How It Works
 

--- a/src/uc_mcp_proxy/__main__.py
+++ b/src/uc_mcp_proxy/__main__.py
@@ -124,6 +124,7 @@ async def run(
     profile: str | None = None,
     auth_type: str | None = None,
     meta: dict[str, str] | None = None,
+    verify_ssl: bool = True,
 ) -> None:
     """Run the proxy: bridge stdio transport to Streamable HTTP with Databricks OAuth."""
     kwargs: dict = {}
@@ -135,12 +136,13 @@ async def run(
     auth = DatabricksAuth(client)
 
     async with stdio_server() as (stdio_read, stdio_write):
-        async with streamablehttp_client(url, auth=auth) as (
-            http_read,
-            http_write,
-            _get_session_id,
-        ):
-            await bridge(stdio_read, stdio_write, http_read, http_write, meta)
+        async with httpx.AsyncClient(verify=verify_ssl) as httpx_client:
+            async with streamablehttp_client(url, auth=auth, httpx_client=httpx_client) as (
+                http_read,
+                http_write,
+                _get_session_id,
+            ):
+                await bridge(stdio_read, stdio_write, http_read, http_write, meta)
 
 
 def main() -> None:
@@ -162,7 +164,19 @@ def main() -> None:
             "on key collision with client-provided _meta."
         ),
     )
+    parser.add_argument(
+        "--no-verify-ssl",
+        action="store_true",
+        help="Disable SSL certificate verification (for self-signed certificates).",
+    )
     args = parser.parse_args()
+
+    if args.no_verify_ssl:
+        print(
+            "warning: SSL certificate verification is disabled (--no-verify-ssl). "
+            "Use only in trusted environments.",
+            file=sys.stderr,
+        )
 
     meta: dict[str, str] | None = None
     if args.meta:
@@ -174,7 +188,7 @@ def main() -> None:
                 sys.exit(1)
             meta[key] = value
 
-    asyncio.run(run(args.url, args.profile, args.auth_type, meta))
+    asyncio.run(run(args.url, args.profile, args.auth_type, meta, verify_ssl=not args.no_verify_ssl))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/uc_mcp_proxy/__main__.py
+++ b/src/uc_mcp_proxy/__main__.py
@@ -11,7 +11,7 @@ import anyio
 import httpx
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from databricks.sdk import WorkspaceClient
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.server.stdio import stdio_server
 from mcp.shared.message import SessionMessage
 from mcp.types import JSONRPCRequest
@@ -136,8 +136,16 @@ async def run(
     auth = DatabricksAuth(client)
 
     async with stdio_server() as (stdio_read, stdio_write):
-        async with httpx.AsyncClient(verify=verify_ssl) as httpx_client:
-            async with streamablehttp_client(url, auth=auth, httpx_client=httpx_client) as (
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            verify=verify_ssl,
+            timeout=httpx.Timeout(30.0, read=300.0),
+            auth=auth,
+        ) as httpx_client:
+            async with streamable_http_client(
+                url,
+                http_client=httpx_client,
+            ) as (
                 http_read,
                 http_write,
                 _get_session_id,

--- a/tests/integration/test_proxy.py
+++ b/tests/integration/test_proxy.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import inspect
+
 import anyio
+import httpx
 import pytest
 from contextlib import asynccontextmanager
 from unittest.mock import patch, MagicMock
+
+from mcp.client.streamable_http import streamable_http_client as _real_streamable_http_client
 
 pytestmark = [pytest.mark.integration, pytest.mark.anyio]
 
@@ -39,7 +44,7 @@ async def test_proxy_forwards_request_and_response(
 
     with patch("uc_mcp_proxy.__main__.WorkspaceClient", return_value=mock_workspace_client):
         with patch("uc_mcp_proxy.__main__.stdio_server", side_effect=fake_stdio):
-            with patch("uc_mcp_proxy.__main__.streamablehttp_client", side_effect=fake_http):
+            with patch("uc_mcp_proxy.__main__.streamable_http_client", side_effect=fake_http):
                 async with anyio.create_task_group() as tg:
                     tg.start_soon(run, "https://example.com/mcp", None)
 
@@ -58,10 +63,10 @@ async def test_proxy_forwards_request_and_response(
                     await http_in_send.aclose()
 
 
-async def test_proxy_passes_auth_directly(
+async def test_proxy_passes_auth_on_http_client(
     mock_workspace_client, memory_stream_pair
 ):
-    """DatabricksAuth is passed directly to streamablehttp_client via auth=."""
+    """DatabricksAuth is configured on the httpx.AsyncClient handed to streamable_http_client."""
     from uc_mcp_proxy.__main__ import run, DatabricksAuth
 
     stdio_in_send, stdio_in_recv = memory_stream_pair(16)
@@ -76,13 +81,13 @@ async def test_proxy_passes_auth_directly(
     captured = {}
 
     @asynccontextmanager
-    async def fake_http(url, *, auth=None, **kwargs):
-        captured["auth"] = auth
+    async def fake_http(url, *, http_client=None, **kwargs):
+        captured["http_client"] = http_client
         yield (http_in_recv, http_out_send, lambda: "mock-session-id")
 
     with patch("uc_mcp_proxy.__main__.WorkspaceClient", return_value=mock_workspace_client):
         with patch("uc_mcp_proxy.__main__.stdio_server", side_effect=fake_stdio):
-            with patch("uc_mcp_proxy.__main__.streamablehttp_client", side_effect=fake_http):
+            with patch("uc_mcp_proxy.__main__.streamable_http_client", side_effect=fake_http):
                 async with anyio.create_task_group() as tg:
                     tg.start_soon(run, "https://example.com/mcp", None)
 
@@ -93,8 +98,8 @@ async def test_proxy_passes_auth_directly(
                     await stdio_in_send.aclose()
                     await http_in_send.aclose()
 
-    assert captured["auth"] is not None
-    assert isinstance(captured["auth"], DatabricksAuth)
+    assert isinstance(captured["http_client"], httpx.AsyncClient)
+    assert isinstance(captured["http_client"].auth, DatabricksAuth)
 
 
 async def test_proxy_uses_correct_url(
@@ -123,7 +128,7 @@ async def test_proxy_uses_correct_url(
 
     with patch("uc_mcp_proxy.__main__.WorkspaceClient", return_value=mock_workspace_client):
         with patch("uc_mcp_proxy.__main__.stdio_server", side_effect=fake_stdio):
-            with patch("uc_mcp_proxy.__main__.streamablehttp_client", side_effect=fake_http):
+            with patch("uc_mcp_proxy.__main__.streamable_http_client", side_effect=fake_http):
                 async with anyio.create_task_group() as tg:
                     tg.start_soon(run, target_url, "DEFAULT")
 
@@ -133,3 +138,49 @@ async def test_proxy_uses_correct_url(
                     await http_in_send.aclose()
 
     assert captured["url"] == target_url
+
+
+async def test_run_calls_streamable_http_client_with_supported_kwargs(
+    mock_workspace_client, memory_stream_pair
+):
+    """Guard: kwargs passed to streamable_http_client must bind to the real SDK signature.
+
+    Without this, fakes with **kwargs silently accept misnamed params and the
+    bug only surfaces at runtime against a live server.
+    """
+    from uc_mcp_proxy.__main__ import run
+
+    stdio_in_send, stdio_in_recv = memory_stream_pair(16)
+    stdio_out_send, stdio_out_recv = memory_stream_pair(16)
+    http_in_send, http_in_recv = memory_stream_pair(16)
+    http_out_send, http_out_recv = memory_stream_pair(16)
+
+    @asynccontextmanager
+    async def fake_stdio():
+        yield (stdio_in_recv, stdio_out_send)
+
+    captured_args: tuple = ()
+    captured_kwargs: dict = {}
+
+    @asynccontextmanager
+    async def fake_http(*args, **kwargs):
+        nonlocal captured_args
+        captured_args = args
+        captured_kwargs.update(kwargs)
+        yield (http_in_recv, http_out_send, lambda: "mock-session-id")
+
+    with patch("uc_mcp_proxy.__main__.WorkspaceClient", return_value=mock_workspace_client):
+        with patch("uc_mcp_proxy.__main__.stdio_server", side_effect=fake_stdio):
+            with patch("uc_mcp_proxy.__main__.streamable_http_client", side_effect=fake_http):
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(run, "https://example.com/mcp", None, None, None, False)
+                    await anyio.sleep(0)
+                    await stdio_in_send.aclose()
+                    await http_in_send.aclose()
+
+    # Bind the captured call against the real SDK signature — this raises
+    # TypeError if our kwargs don't match what the installed mcp exposes.
+    sig = inspect.signature(_real_streamable_http_client)
+    sig.bind(*captured_args, **captured_kwargs)
+
+    assert isinstance(captured_kwargs["http_client"], httpx.AsyncClient)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -38,7 +38,7 @@ def test_default_profile_is_none():
             with patch("uc_mcp_proxy.__main__.asyncio.run"):
                 from uc_mcp_proxy.__main__ import main
                 main()
-                mock_run.assert_called_once_with("https://example.com/mcp", None, None, None)
+                mock_run.assert_called_once_with("https://example.com/mcp", None, None, None, verify_ssl=True)
 
 
 def test_creates_workspace_client_with_profile():
@@ -51,7 +51,7 @@ def test_creates_workspace_client_with_profile():
             with patch("uc_mcp_proxy.__main__.asyncio.run"):
                 from uc_mcp_proxy.__main__ import main
                 main()
-                mock_run.assert_called_once_with("https://example.com/mcp", "MY_PROFILE", None, None)
+                mock_run.assert_called_once_with("https://example.com/mcp", "MY_PROFILE", None, None, verify_ssl=True)
 
 
 def test_creates_workspace_client_with_auth_type():
@@ -64,7 +64,7 @@ def test_creates_workspace_client_with_auth_type():
             with patch("uc_mcp_proxy.__main__.asyncio.run"):
                 from uc_mcp_proxy.__main__ import main
                 main()
-                mock_run.assert_called_once_with("https://example.com/mcp", None, "databricks-cli", None)
+                mock_run.assert_called_once_with("https://example.com/mcp", None, "databricks-cli", None, verify_ssl=True)
 
 
 def test_single_meta_parsed_correctly():
@@ -81,6 +81,7 @@ def test_single_meta_parsed_correctly():
                 mock_run.assert_called_once_with(
                     "https://example.com/mcp", None, None,
                     {"warehouse_id": "abc123"},
+                    verify_ssl=True,
                 )
 
 
@@ -99,6 +100,7 @@ def test_multiple_meta_parsed_correctly():
                 mock_run.assert_called_once_with(
                     "https://example.com/mcp", None, None,
                     {"warehouse_id": "abc123", "catalog": "main"},
+                    verify_ssl=True,
                 )
 
 
@@ -122,4 +124,46 @@ def test_no_meta_passes_none():
             with patch("uc_mcp_proxy.__main__.asyncio.run"):
                 from uc_mcp_proxy.__main__ import main
                 main()
-                mock_run.assert_called_once_with("https://example.com/mcp", None, None, None)
+                mock_run.assert_called_once_with("https://example.com/mcp", None, None, None, verify_ssl=True)
+
+
+def test_no_verify_ssl_passes_verify_ssl_false():
+    """--no-verify-ssl passes verify_ssl=False to run()."""
+    with patch.object(sys, "argv", [
+        "uc-mcp-proxy", "--url", "https://example.com/mcp", "--no-verify-ssl"
+    ]):
+        with patch("uc_mcp_proxy.__main__.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            with patch("uc_mcp_proxy.__main__.asyncio.run"):
+                from uc_mcp_proxy.__main__ import main
+                main()
+                mock_run.assert_called_once_with(
+                    "https://example.com/mcp", None, None, None, verify_ssl=False
+                )
+
+
+def test_no_verify_ssl_prints_warning(capsys):
+    """--no-verify-ssl prints a warning to stderr."""
+    with patch.object(sys, "argv", [
+        "uc-mcp-proxy", "--url", "https://example.com/mcp", "--no-verify-ssl"
+    ]):
+        with patch("uc_mcp_proxy.__main__.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            with patch("uc_mcp_proxy.__main__.asyncio.run"):
+                from uc_mcp_proxy.__main__ import main
+                main()
+        captured = capsys.readouterr()
+        assert "warning" in captured.err.lower()
+        assert "ssl" in captured.err.lower()
+
+
+def test_without_no_verify_ssl_defaults_to_verify_true():
+    """Without --no-verify-ssl, verify_ssl defaults to True."""
+    with patch.object(sys, "argv", ["uc-mcp-proxy", "--url", "https://example.com/mcp"]):
+        with patch("uc_mcp_proxy.__main__.run") as mock_run:
+            mock_run.return_value = MagicMock()
+            with patch("uc_mcp_proxy.__main__.asyncio.run"):
+                from uc_mcp_proxy.__main__ import main
+                main()
+                _, kwargs = mock_run.call_args
+                assert kwargs.get("verify_ssl", True) is True

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import sys
+from contextlib import asynccontextmanager
 from unittest.mock import patch, MagicMock
 
+import anyio
+import httpx
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -167,3 +170,44 @@ def test_without_no_verify_ssl_defaults_to_verify_true():
                 main()
                 _, kwargs = mock_run.call_args
                 assert kwargs.get("verify_ssl", True) is True
+
+
+@pytest.mark.parametrize("verify_ssl", [True, False])
+def test_run_builds_httpx_client_with_expected_verify(mock_workspace_client, verify_ssl):
+    """run(verify_ssl=...) constructs httpx.AsyncClient with the matching verify= kwarg.
+
+    This is the load-bearing plumbing check for --no-verify-ssl: prove the flag
+    actually reaches the httpx constructor, not just the run() signature.
+    """
+    from uc_mcp_proxy.__main__ import run
+
+    captured: dict = {}
+    real_async_client = httpx.AsyncClient
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return real_async_client(*args, **kwargs)
+
+    @asynccontextmanager
+    async def fake_stdio():
+        send_a, recv_a = anyio.create_memory_object_stream(1)
+        send_b, recv_b = anyio.create_memory_object_stream(1)
+        # Close source sends so bridge()'s copy_stream tasks EOF immediately
+        # and run() returns without hanging.
+        await send_a.aclose()
+        yield (recv_a, send_b)
+
+    @asynccontextmanager
+    async def fake_http(url, *, http_client=None, **kwargs):
+        send_a, recv_a = anyio.create_memory_object_stream(1)
+        send_b, recv_b = anyio.create_memory_object_stream(1)
+        await send_a.aclose()
+        yield (recv_a, send_b, lambda: "mock-session-id")
+
+    with patch("uc_mcp_proxy.__main__.WorkspaceClient", return_value=mock_workspace_client):
+        with patch("uc_mcp_proxy.__main__.stdio_server", side_effect=fake_stdio):
+            with patch("uc_mcp_proxy.__main__.streamable_http_client", side_effect=fake_http):
+                with patch("uc_mcp_proxy.__main__.httpx.AsyncClient", side_effect=spy):
+                    anyio.run(run, "https://example.com/mcp", None, None, None, verify_ssl)
+
+    assert captured.get("verify") is verify_ssl

--- a/uv.lock
+++ b/uv.lock
@@ -1205,7 +1205,7 @@ wheels = [
 
 [[package]]
 name = "uc-mcp-proxy"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Adds `--no-verify-ssl` CLI flag for Azure Databricks (and other) instances that use self-signed certificates, causing `SSL_CERTIFICATE_VERIFY_FAILED` errors.

Closes #12

## Changes

- `run()` accepts `verify_ssl: bool = True` parameter
- Creates `httpx.AsyncClient(verify=verify_ssl)` passed to `streamablehttp_client(httpx_client=...)`
- `--no-verify-ssl` argparse flag with stderr warning about security implications
- Unit tests for flag parsing and httpx client configuration

## Usage

```sh
uvx uc-mcp-proxy \
  --url https://your-azure-workspace.databricks.com/api/2.0/mcp/... \
  --no-verify-ssl
```

> ⚠️ Only use `--no-verify-ssl` in trusted network environments. Disabling SSL verification exposes connections to man-in-the-middle attacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)