### PR TITLE
feat: Support workspace-relative URL resolution

### DIFF
--- a/src/uc_mcp_proxy/__main__.py
+++ b/src/uc_mcp_proxy/__main__.py
@@ -7,6 +7,7 @@ import asyncio
 import sys
 from collections.abc import AsyncGenerator, Generator
 from typing import Any
+from urllib.parse import urljoin, urlsplit
 
 import anyio
 import httpx
@@ -122,6 +123,24 @@ async def bridge(
         tg.start_soon(copy_stream, http_read, stdio_write)
 
 
+def _resolve_url(url: str, client: WorkspaceClient) -> str:
+    """Resolve ``url`` against the workspace host from ``client.config``.
+
+    If ``url`` already has a scheme (e.g. ``https://...``) it is returned
+    unchanged. Otherwise it is joined against ``client.config.host`` so that
+    callers can pass a workspace-relative path like ``/api/2.0/mcp/foo``.
+    """
+    if urlsplit(url).scheme:
+        return url
+    host = client.config.host
+    if not host:
+        raise SystemExit(
+            f"uc-mcp-proxy: --url {url!r} is relative but no workspace host is configured in the Databricks profile."
+        )
+    base = host if host.endswith("/") else host + "/"
+    return urljoin(base, url.lstrip("/"))
+
+
 async def run(
     url: str,
     profile: str | None = None,
@@ -130,7 +149,11 @@ async def run(
     verify_ssl: bool = True,
     no_auto_login: bool = False,
 ) -> None:
-    """Run the proxy: bridge stdio transport to Streamable HTTP with Databricks OAuth."""
+    """Run the proxy: bridge stdio transport to Streamable HTTP with Databricks OAuth.
+
+    ``url`` may be absolute or workspace-relative; relative values are resolved
+    against ``client.config.host`` from the Databricks profile.
+    """
     if no_auto_login:
         kwargs: dict[str, Any] = {}
         if profile:
@@ -141,6 +164,7 @@ async def run(
     else:
         client = _preflight_authenticate(profile, auth_type)
     auth = DatabricksAuth(client)
+    resolved_url = _resolve_url(url, client)
 
     async with (
         stdio_server() as (stdio_read, stdio_write),
@@ -151,7 +175,7 @@ async def run(
             auth=auth,
         ) as httpx_client,
         streamable_http_client(
-            url,
+            resolved_url,
             http_client=httpx_client,
         ) as (
             http_read,
@@ -167,7 +191,16 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="MCP stdio-to-Streamable-HTTP proxy with Databricks OAuth",
     )
-    parser.add_argument("--url", required=True, help="Remote MCP server URL")
+    parser.add_argument(
+        "--url",
+        required=True,
+        help=(
+            "Remote MCP server URL. Accepts an absolute URL "
+            "(https://workspace/api/2.0/mcp/...) or a workspace-relative path "
+            "(/api/2.0/mcp/...), which is resolved against the host from the "
+            "Databricks profile."
+        ),
+    )
     parser.add_argument("--profile", default=None, help="Databricks CLI profile")
     parser.add_argument("--auth-type", default=None, help="Databricks auth type (e.g. databricks-cli)")
     parser.add_argument(

--- a/tests/unit/test_resolve_url.py
+++ b/tests/unit/test_resolve_url.py
@@ -1,0 +1,82 @@
+"""Tests for workspace-relative --url resolution."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import anyio
+import pytest
+
+from uc_mcp_proxy.__main__ import _resolve_url, run
+
+pytestmark = pytest.mark.unit
+
+
+def test_absolute_url_passthrough(mock_workspace_client):
+    """An absolute URL is returned unchanged."""
+    assert (
+        _resolve_url("https://example.com/api/2.0/mcp/foo", mock_workspace_client)
+        == "https://example.com/api/2.0/mcp/foo"
+    )
+
+
+def test_relative_url_joined_with_host(mock_workspace_client):
+    """A leading-slash relative URL is joined against config.host."""
+    assert (
+        _resolve_url("/api/2.0/mcp/foo", mock_workspace_client)
+        == "https://test-workspace.cloud.databricks.com/api/2.0/mcp/foo"
+    )
+
+
+def test_relative_url_no_leading_slash(mock_workspace_client):
+    """A relative URL without a leading slash still resolves under the host."""
+    assert (
+        _resolve_url("api/2.0/mcp/foo", mock_workspace_client)
+        == "https://test-workspace.cloud.databricks.com/api/2.0/mcp/foo"
+    )
+
+
+def test_relative_url_host_with_trailing_slash(mock_workspace_client):
+    """Host already ending in '/' does not produce a double slash."""
+    mock_workspace_client.config.host = "https://test-workspace.cloud.databricks.com/"
+    assert (
+        _resolve_url("/api/2.0/mcp/foo", mock_workspace_client)
+        == "https://test-workspace.cloud.databricks.com/api/2.0/mcp/foo"
+    )
+
+
+def test_relative_url_missing_host_raises(mock_workspace_client):
+    """Relative URL with no configured host exits with an error."""
+    mock_workspace_client.config.host = None
+    with pytest.raises(SystemExit):
+        _resolve_url("/api/2.0/mcp/foo", mock_workspace_client)
+
+
+def test_run_resolves_relative_url(mock_workspace_client):
+    """run() forwards the resolved absolute URL to streamable_http_client."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def fake_stdio():
+        send_a, recv_a = anyio.create_memory_object_stream(1)
+        send_b, _recv_b = anyio.create_memory_object_stream(1)
+        await send_a.aclose()
+        yield (recv_a, send_b)
+
+    @asynccontextmanager
+    async def fake_http(url, *, http_client=None, **kwargs):
+        captured["url"] = url
+        send_a, recv_a = anyio.create_memory_object_stream(1)
+        send_b, _recv_b = anyio.create_memory_object_stream(1)
+        await send_a.aclose()
+        yield (recv_a, send_b, lambda: "mock-session-id")
+
+    with (
+        patch("uc_mcp_proxy.__main__.WorkspaceClient", return_value=mock_workspace_client),
+        patch("uc_mcp_proxy.__main__.stdio_server", side_effect=fake_stdio),
+        patch("uc_mcp_proxy.__main__.streamable_http_client", side_effect=fake_http),
+    ):
+        anyio.run(run, "/api/2.0/mcp/foo", None, None, None, True, True)
+
+    assert captured["url"] == "https://test-workspace.cloud.databricks.com/api/2.0/mcp/foo"

--- a/uv.lock
+++ b/uv.lock
@@ -1438,7 +1438,7 @@ wheels = [
 
 [[package]]
 name = "uc-mcp-proxy"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Add _resolve_url() function to resolve workspace-relative paths against the configured Databricks host. Absolute URLs are passed through unchanged, while relative paths (with or without leading slash) are joined against client.config.host.